### PR TITLE
Added Asset Editor Toolbar class

### DIFF
--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphAssetEditor.h
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphAssetEditor.h
@@ -1,5 +1,7 @@
 #pragma once
 
+class FGenericGraphAssetEditorToolbar;
+
 class FGenericGraphAssetEditor : public FAssetEditorToolkit, public FNotifyHook, public FGCObject
 {
 public:
@@ -24,6 +26,12 @@ public:
 	virtual void SaveAsset_Execute() override;
 	// End of FAssetEditorToolkit
 
+	//Toolbar
+	void UpdateToolbar();
+	TSharedPtr<class FGenericGraphAssetEditorToolbar> GetToolbarBuilder() { return ToolbarBuilder; }
+	void RegisterToolbarTab(const TSharedRef<class FTabManager>& TabManager);
+
+
 	// FSerializableObject interface
 	virtual void AddReferencedObjects(FReferenceCollector& Collector) override;
 	// End of FSerializableObject interface
@@ -35,7 +43,6 @@ private:
 	void CreateInternalWidgets();
 	TSharedRef<SGraphEditor> CreateViewportWidget();
 
-	void ExtendToolbar();
 
 	void BindCommands();
 
@@ -78,8 +85,12 @@ private:
 
 	void OnPackageSaved(const FString& PackageFileName, UObject* Outer);
 
+
 private:
 	UGenericGraph* EditingGraph;
+
+	//Toolbar
+	TSharedPtr<class FGenericGraphAssetEditorToolbar> ToolbarBuilder;
 
 	/** Handle to the registered OnPackageSave delegate */
 	FDelegateHandle OnPackageSavedDelegateHandle;

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphAssetEditorToolbar.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphAssetEditorToolbar.cpp
@@ -1,0 +1,41 @@
+#include "GenericGraphEditorPrivatePCH.h"
+#include "GenericGraphAssetEditorToolbar.h"
+#include "GenericGraphAssetEditor.h"
+#include "GenericGraphEditorCommands.h"
+
+
+#define LOCTEXT_NAMESPACE "GenericGraphAssetEditorToolbar"
+
+void FGenericGraphAssetEditorToolbar::AddGenericGraphToolbar(TSharedPtr<FExtender> Extender)
+{
+	check(GenericGraphEditor.IsValid());
+	TSharedPtr<FGenericGraphAssetEditor> GenericGraphEditorPtr = GenericGraphEditor.Pin();
+
+	TSharedPtr<FExtender> ToolbarExtender = MakeShareable(new FExtender);
+	ToolbarExtender->AddToolBarExtension("Asset", EExtensionHook::After, GenericGraphEditorPtr->GetToolkitCommands(), FToolBarExtensionDelegate::CreateSP( this, &FGenericGraphAssetEditorToolbar::FillGenericGraphToolbar ));
+	GenericGraphEditorPtr->AddToolbarExtender(ToolbarExtender);
+}
+
+void FGenericGraphAssetEditorToolbar::FillGenericGraphToolbar(FToolBarBuilder& ToolbarBuilder)
+{
+	check(GenericGraphEditor.IsValid());
+	TSharedPtr<FGenericGraphAssetEditor> GenericGraphEditorPtr = GenericGraphEditor.Pin();
+
+	ToolbarBuilder.BeginSection("Generic Graph");
+	{
+
+		const FText GraphSettingsLabel = LOCTEXT("GraphSettings_Label", "Graph Settings");
+		const FText GraphSettingsTip = LOCTEXT("GraphSettings_ToolTip", "Show the Graph Settings");
+		const FSlateIcon GraphSettingsIcon = FSlateIcon(FEditorStyle::GetStyleSetName(), "LevelEditor.GameSettings");
+		ToolbarBuilder.AddToolBarButton(FGenericGraphEditorCommands::Get().GraphSettings, 
+			NAME_None,
+			GraphSettingsLabel,
+			GraphSettingsTip,
+			GraphSettingsIcon);
+	}
+	ToolbarBuilder.EndSection();
+
+}
+
+
+#undef LOCTEXT_NAMESPACE

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphAssetEditorToolbar.h
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphAssetEditorToolbar.h
@@ -1,0 +1,28 @@
+
+#pragma once
+
+#include "CoreMinimal.h"
+
+class FGenericGraphAssetEditor;
+class FExtender;
+class FToolBarBuilder;
+
+class FGenericGraphAssetEditorToolbar : public TSharedFromThis<FGenericGraphAssetEditorToolbar>
+{
+public:
+	FGenericGraphAssetEditorToolbar(TSharedPtr<FGenericGraphAssetEditor> InGenericGraphEditor)
+		: GenericGraphEditor(InGenericGraphEditor) {}
+
+	//void AddModesToolbar(TSharedPtr<FExtender> Extender);
+	//void AddDebuggerToolbar(TSharedPtr<FExtender> Extender);
+	void AddGenericGraphToolbar(TSharedPtr<FExtender> Extender);
+
+private:
+	//void FillModesToolbar(FToolBarBuilder& ToolbarBuilder);
+	//void FillDebuggerToolbar(FToolBarBuilder& ToolbarBuilder);
+	void FillGenericGraphToolbar(FToolBarBuilder& ToolbarBuilder);
+
+protected:
+	/** Pointer back to the blueprint editor tool that owns us */
+	TWeakPtr<FGenericGraphAssetEditor> GenericGraphEditor;
+};

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphAssetGraphSchema.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphAssetGraphSchema.cpp
@@ -132,7 +132,7 @@ void UGenericGraphAssetGraphSchema::GetGraphContextActions(FGraphContextMenuBuil
 
 	const FText AddToolTip = LOCTEXT("NewGenericGraphNodeTooltip", "Add node here");
 	const FText Desc = LOCTEXT("NewGenericGraphNodeTooltip", "Add Node");
-	TSharedPtr<FGenericGraphAssetSchemaAction_NewNode> NewNodeAction(new FGenericGraphAssetSchemaAction_NewNode(LOCTEXT("GenericGraphNodeAction", "Generic Graph Node"), Desc, AddToolTip.ToString(), 0));
+	TSharedPtr<FGenericGraphAssetSchemaAction_NewNode> NewNodeAction(new FGenericGraphAssetSchemaAction_NewNode(LOCTEXT("GenericGraphNodeAction", "Generic Graph Node"), Desc, AddToolTip, 0));
 
 	ContextMenuBuilder.AddAction(NewNodeAction);
 }

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphAssetGraphSchema.h
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphAssetGraphSchema.h
@@ -12,7 +12,7 @@ struct FGenericGraphAssetSchemaAction_NewNode : public FEdGraphSchemaAction
 		: FEdGraphSchemaAction()
 	{}
 
-	FGenericGraphAssetSchemaAction_NewNode(const FText& InNodeCategory, const FText& InMenuDesc, const FString& InToolTip, const int32 InGrouping)
+	FGenericGraphAssetSchemaAction_NewNode(const FText& InNodeCategory, const FText& InMenuDesc, const FText& InToolTip, const int32 InGrouping)
 		: FEdGraphSchemaAction(InNodeCategory, InMenuDesc, InToolTip, InGrouping) 
 	{}
 

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphEdNode.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphEdNode.cpp
@@ -48,4 +48,9 @@ FText UGenericGraphEdNode::GetDescription() const
 	return FText::FromString(C->GetDescription());
 }
 
+FLinearColor UGenericGraphEdNode::GetBackgroundColor() const
+{
+	return GenericGraphNode->BackgroundColor;
+}
+
 #undef LOCTEXT_NAMESPACE

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphEdNode.h
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/GenericGraphEdNode.h
@@ -21,4 +21,6 @@ public:
 	void SetGenericGraphNode(UGenericGraphNode* InNode);
 
 	virtual FText GetDescription() const;
+
+	virtual FLinearColor GetBackgroundColor() const;
 };

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/SGenericGraphEdNode.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/SGenericGraphEdNode.cpp
@@ -316,7 +316,8 @@ END_SLATE_FUNCTION_BUILD_OPTIMIZATION
 
 FSlateColor SGenericGraphEdNode::GetBorderBackgroundColor() const
 {
-	return GenericGraphColors::NodeBorder::HighlightAbortRange0;
+	UGenericGraphEdNode* MyNode = CastChecked<UGenericGraphEdNode>(GraphNode);
+	return MyNode ? MyNode->GetBackgroundColor() : GenericGraphColors::NodeBorder::HighlightAbortRange0;
 }
 
 FSlateColor SGenericGraphEdNode::GetBackgroundColor() const

--- a/Source/GenericGraphRuntime/Classes/GenericGraphNode.h
+++ b/Source/GenericGraphRuntime/Classes/GenericGraphNode.h
@@ -21,16 +21,31 @@ public:
 	UPROPERTY(EditAnywhere, BlueprintReadOnly, Category = "GenericGraphNode")
 	FString CustomNodeTitle;
 
+
 	UPROPERTY(BlueprintReadOnly, Category = "GenericGraphNode")
 	TArray<UGenericGraphNode*> ParentNodes;
 
 	UPROPERTY(BlueprintReadOnly, Category = "GenericGraphNode")
 	TArray<UGenericGraphNode*> ChildrenNodes;
 
+	UPROPERTY(Transient)
+	AActor* ActorOwner;
+
+#if WITH_EDITOR
+	UPROPERTY(EditDefaultsOnly, Category = "GenericGraphNode")
+	FLinearColor BackgroundColor;
+#endif
+
 	//////////////////////////////////////////////////////////////////////////
 	// ufunctions
 	UFUNCTION(BlueprintCallable, Category = "GenericGraphNode")
 	FString GetNodeTitle();
+
+	UFUNCTION(BlueprintCallable, BlueprintImplementableEvent)
+	void EnterNode(AActor* OwnerActor);
+
+	UFUNCTION(BlueprintCallable, BlueprintImplementableEvent)
+	void ExitNode(AActor* OwnerActor);
 
 	//////////////////////////////////////////////////////////////////////////
 	UGenericGraph* GetGraph();

--- a/Source/GenericGraphRuntime/Private/GenericGraphNode.cpp
+++ b/Source/GenericGraphRuntime/Private/GenericGraphNode.cpp
@@ -6,6 +6,7 @@
 UGenericGraphNode::UGenericGraphNode()
 {
 	NodeType = AActor::StaticClass();
+	BackgroundColor = FLinearColor(0.0f, 0.0f, 0.0f, 1.0f);
 }
 
 UGenericGraphNode::~UGenericGraphNode()


### PR DESCRIPTION
Moved the Toolbar of the GraphEditor to it's own class and fixed a bug when clicking it didn't show the graphs settings.
Also added a Color option for the nodes and a Enter Node Function.
Fixed the NewNodeAction Signature since it wasn't accepting a FString anymore and required a FText. (in Engine version 4.16.1)