### PR TITLE
Fix bad edge connections

### DIFF
--- a/Source/GenericGraphEditor/Private/AssetTypeActions_GenericGraph.cpp
+++ b/Source/GenericGraphEditor/Private/AssetTypeActions_GenericGraph.cpp
@@ -40,7 +40,7 @@ void FAssetTypeActions_GenericGraph::OpenAssetEditor(const TArray<UObject*>& InO
 
 uint32 FAssetTypeActions_GenericGraph::GetCategories()
 {
-	return EAssetTypeCategories::Animation | MyAssetCategory;
+	return MyAssetCategory;
 }
 
 //////////////////////////////////////////////////////////////////////////

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetEditor_GenericGraph.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetEditor_GenericGraph.cpp
@@ -165,12 +165,12 @@ FText FAssetEditor_GenericGraph::GetBaseToolkitName() const
 
 FText FAssetEditor_GenericGraph::GetToolkitName() const
 {
-	const bool bDirtyState = EditingGraph->GetOutermost()->IsDirty();
+	if (EditingGraph != nullptr)
+	{
+		return FAssetEditorToolkit::GetLabelForObject(EditingGraph);
+	}
 
-	FFormatNamedArguments Args;
-	Args.Add(TEXT("GenericGraphName"), FText::FromString(EditingGraph->GetName()));
-	Args.Add(TEXT("DirtyState"), bDirtyState ? FText::FromString(TEXT("*")) : FText::GetEmpty());
-	return FText::Format(LOCTEXT("GenericGraphEditorToolkitName", "{GenericGraphName}{DirtyState}"), Args);
+	return FText();
 }
 
 FText FAssetEditor_GenericGraph::GetToolkitToolTipText() const

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetGraphSchema_GenericGraph.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetGraphSchema_GenericGraph.cpp
@@ -340,6 +340,22 @@ const FPinConnectionResponse UAssetGraphSchema_GenericGraph::CanCreateConnection
 		return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, LOCTEXT("PinError", "Not a valid UGenericGraphEdNode"));
 	}
 
+	// Check that this edge doesn't already exist
+	for (UEdGraphPin *TestPin : EdNode_Out->GetOutputPin()->LinkedTo)
+	{
+		UEdGraphNode* ChildNode = TestPin->GetOwningNode();
+		if (UEdNode_GenericGraphEdge* EdNode_Edge = Cast<UEdNode_GenericGraphEdge>(ChildNode))
+		{
+			ChildNode = EdNode_Edge->GetEndNode();
+		}
+
+		if (ChildNode == EdNode_In)
+		{
+			return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, LOCTEXT("PinError", "Nodes are already connected"));
+		}
+	}
+
+
 	FText ErrorMessage;
 	if (!EdNode_Out->GenericGraphNode->CanCreateConnection(EdNode_In->GenericGraphNode, ErrorMessage))
 	{

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetGraphSchema_GenericGraph.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetGraphSchema_GenericGraph.cpp
@@ -357,7 +357,7 @@ const FPinConnectionResponse UAssetGraphSchema_GenericGraph::CanCreateConnection
 
 
 	FText ErrorMessage;
-	if (!EdNode_Out->GenericGraphNode->CanCreateConnection(EdNode_In->GenericGraphNode, ErrorMessage))
+	if (!EdNode_Out->GenericGraphNode->CanCreateConnection(EdNode_In->GenericGraphNode, EdNode_In->Pins[1]->LinkedTo.Num(),EdNode_Out->Pins[0]->LinkedTo.Num(), ErrorMessage))
 	{
 		return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, ErrorMessage);
 	}

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetGraphSchema_GenericGraph.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetGraphSchema_GenericGraph.cpp
@@ -357,10 +357,15 @@ const FPinConnectionResponse UAssetGraphSchema_GenericGraph::CanCreateConnection
 
 
 	FText ErrorMessage;
-	if (!EdNode_Out->GenericGraphNode->CanCreateConnection(EdNode_In->GenericGraphNode, EdNode_In->Pins[1]->LinkedTo.Num(),EdNode_Out->Pins[0]->LinkedTo.Num(), ErrorMessage))
+	if (!EdNode_Out->GenericGraphNode->CanCreateConnectionTo(EdNode_In->GenericGraphNode, EdNode_Out->GetOutputPin()->LinkedTo.Num(), ErrorMessage))
 	{
 		return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, ErrorMessage);
 	}
+	if (!EdNode_In->GenericGraphNode->CanCreateConnectionFrom(EdNode_Out->GenericGraphNode, EdNode_In->GetInputPin()->LinkedTo.Num(), ErrorMessage))
+	{
+		return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, ErrorMessage);
+	}
+
 
 	if (EdNode_Out->GenericGraphNode->GetGraph()->bEdgeEnabled)
 	{

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetGraphSchema_GenericGraph.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetGraphSchema_GenericGraph.cpp
@@ -325,9 +325,17 @@ const FPinConnectionResponse UAssetGraphSchema_GenericGraph::CanCreateConnection
 		In = A;
 	}
 		
+	//Determine if we can have cycles or not
+	bool bAllowCycles = false;
+	auto EdGraph = Cast<UEdGraph_GenericGraph>(A->GetOwningNode()->GetGraph());
+	if (EdGraph != nullptr)
+	{
+		bAllowCycles = EdGraph->GetGenericGraph()->bCanBeCyclical;
+	}
+
 	// check for cycles
 	FNodeVisitorCycleChecker CycleChecker;
-	if (!CycleChecker.CheckForLoop(Out->GetOwningNode(), In->GetOwningNode()))
+	if (!bAllowCycles && !CycleChecker.CheckForLoop(Out->GetOwningNode(), In->GetOwningNode()))
 	{
 		return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, LOCTEXT("PinErrorCycle", "Can't create a graph cycle"));
 	}

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/SEdNode_GenericGraphEdge.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/SEdNode_GenericGraphEdge.cpp
@@ -123,6 +123,11 @@ void SEdNode_GenericGraphEdge::PositionBetweenTwoNodesWithOffset(const FGeometry
 
 FSlateColor SEdNode_GenericGraphEdge::GetEdgeColor() const
 {
+	UEdNode_GenericGraphEdge* EdgeNode = CastChecked<UEdNode_GenericGraphEdge>(GraphNode);
+	if (EdgeNode != nullptr && EdgeNode->GenericGraphEdge != nullptr)
+	{
+		return EdgeNode->GenericGraphEdge->GetEdgeColour();
+	}
 	return FLinearColor(0.9f, 0.9f, 0.9f, 1.0f);
 }
 

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/SEdNode_GenericGraphNode.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/SEdNode_GenericGraphNode.cpp
@@ -76,122 +76,93 @@ void SEdNode_GenericGraphNode::UpdateGraphNode()
 	// Reset variables that are going to be exposed, in case we are refreshing an already setup node.
 	RightNodeBox.Reset();
 	LeftNodeBox.Reset();
-	OutputPinBox.Reset();
 
+	const FSlateBrush *NodeTypeIcon = GetNameIcon();
+
+	FLinearColor TitleShadowColor(0.6f, 0.6f, 0.6f);
 	TSharedPtr<SErrorText> ErrorText;
+	TSharedPtr<SVerticalBox> NodeBody;
 	TSharedPtr<SNodeTitle> NodeTitle = SNew(SNodeTitle, GraphNode);
 
 	this->ContentScale.Bind(this, &SGraphNode::GetContentScale);
 	this->GetOrAddSlot(ENodeZone::Center)
-		.HAlign(HAlign_Fill)
+		.HAlign(HAlign_Center)
 		.VAlign(VAlign_Center)
 		[
 			SNew(SBorder)
 			.BorderImage(FEditorStyle::GetBrush("Graph.StateNode.Body"))
-			.Padding(0.0f)
+			.Padding(0)
 			.BorderBackgroundColor(this, &SEdNode_GenericGraphNode::GetBorderBackgroundColor)
 			[
 				SNew(SOverlay)
 
-				// Pins and node details
-				+ SOverlay::Slot()
+				// PIN AREA
+				+SOverlay::Slot()
 				.HAlign(HAlign_Fill)
 				.VAlign(VAlign_Fill)
 				[
-					SNew(SVerticalBox)
+					SAssignNew(RightNodeBox, SVerticalBox)
+				]
 
-					// INPUT PIN AREA
-					+ SVerticalBox::Slot()
-					.AutoHeight()
+				// NAME AREA
+				+ SOverlay::Slot()
+				.HAlign(HAlign_Center)
+				.VAlign(VAlign_Center)
+				.Padding(8.0f)
+				[
+					SNew(SBorder)
+					.BorderImage(FEditorStyle::GetBrush("Graph.StateNode.ColorSpill"))
+					.BorderBackgroundColor(TitleShadowColor)
+					.HAlign(HAlign_Center)
+					.VAlign(VAlign_Center)
+					.Visibility(EVisibility::SelfHitTestInvisible)
+					.Padding(6.0f)
 					[
-						SNew(SBox)
-						.MinDesiredHeight(NodePadding.Top)
-						[
-							SAssignNew(LeftNodeBox, SVerticalBox)
-						]
-					]
+						SAssignNew(NodeBody, SVerticalBox)
 
-					// STATE NAME AREA
-					+ SVerticalBox::Slot()
-					.Padding(FMargin(NodePadding.Left, 0.0f, NodePadding.Right, 0.0f))
-					[
-						SNew(SVerticalBox)
-						+ SVerticalBox::Slot()
+						// Title
+						+SVerticalBox::Slot()
 						.AutoHeight()
 						[
-							SAssignNew(NodeBody, SBorder)
-							.BorderImage(FEditorStyle::GetBrush("BTEditor.Graph.BTNode.Body"))
-							.BorderBackgroundColor(this, &SEdNode_GenericGraphNode::GetBackgroundColor)
-							.HAlign(HAlign_Fill)
-							.VAlign(VAlign_Center)
-							.Visibility(EVisibility::SelfHitTestInvisible)
-							[
-								SNew(SOverlay)
-								+ SOverlay::Slot()
-								.HAlign(HAlign_Fill)
-								.VAlign(VAlign_Fill)
-								[
-									SNew(SVerticalBox)
-									+ SVerticalBox::Slot()
-									.AutoHeight()
-									[
-										SNew(SHorizontalBox)
-										+ SHorizontalBox::Slot()
-										.AutoWidth()
-										[
-											// POPUP ERROR MESSAGE
-											SAssignNew(ErrorText, SErrorText)
-											.BackgroundColor(this, &SEdNode_GenericGraphNode::GetErrorColor)
-											.ToolTipText(this, &SEdNode_GenericGraphNode::GetErrorMsgToolTip)
-										]
+							SNew(SHorizontalBox)
 
-										+ SHorizontalBox::Slot()
-										.AutoWidth()
-										[
-											SNew(SHorizontalBox)
-											+ SHorizontalBox::Slot()
-											.Padding(FMargin(4.0f, 0.0f, 4.0f, 0.0f))
-											[
-												SNew(SVerticalBox)
-												+ SVerticalBox::Slot()
-												.AutoHeight()
-												[
-													SAssignNew(InlineEditableText, SInlineEditableTextBlock)
-													.Style(FEditorStyle::Get(), "Graph.StateNode.NodeTitleInlineEditableText")
-													.Text(NodeTitle.Get(), &SNodeTitle::GetHeadTitle)
-													.OnVerifyTextChanged(this, &SEdNode_GenericGraphNode::OnVerifyNameTextChanged)
-													.OnTextCommitted(this, &SEdNode_GenericGraphNode::OnNameTextCommited)
-													.IsReadOnly(this, &SEdNode_GenericGraphNode::IsNameReadOnly)
-													.IsSelected(this, &SEdNode_GenericGraphNode::IsSelectedExclusively)
-												]
-												+ SVerticalBox::Slot()
-												.AutoHeight()
-												[
-													NodeTitle.ToSharedRef()
-												]
-											]
-										]
-									]
-								]
+							// Error message
+							+SHorizontalBox::Slot()
+							.AutoWidth()
+							[
+								SAssignNew(ErrorText, SErrorText)
+								.BackgroundColor(this, &SEdNode_GenericGraphNode::GetErrorColor)
+								.ToolTipText(this, &SEdNode_GenericGraphNode::GetErrorMsgToolTip)
 							]
-						]
-					]
-
-					// OUTPUT PIN AREA
-					+ SVerticalBox::Slot()
-					.AutoHeight()
-					[
-						SNew(SBox)
-						.MinDesiredHeight(NodePadding.Bottom)
-						[
-							SAssignNew(RightNodeBox, SVerticalBox)
-							+ SVerticalBox::Slot()
-							.HAlign(HAlign_Fill)
-							.VAlign(VAlign_Fill)
-							.Padding(20.0f, 0.0f)
-							.FillHeight(1.0f)
+							// Icon
+							+SHorizontalBox::Slot()
+							.AutoWidth()
+							.VAlign(VAlign_Center)
 							[
-								SAssignNew(OutputPinBox, SHorizontalBox)
+								SNew(SImage)
+								.Image(NodeTypeIcon)
+							]
+							// Node Title
+							+SHorizontalBox::Slot()
+							.Padding(FMargin(4.0f, 0.0f, 4.0f, 0.0f))
+							[
+								SNew(SVerticalBox)
+								+SVerticalBox::Slot()
+								.AutoHeight()
+								[
+									SAssignNew(InlineEditableText, SInlineEditableTextBlock)
+									.Style(FEditorStyle::Get(), "Graph.StateNode.NodeTitleInlineEditableText")
+									.Text(NodeTitle.Get(), &SNodeTitle::GetHeadTitle)
+									.OnVerifyTextChanged(this, &SEdNode_GenericGraphNode::OnVerifyNameTextChanged)
+									.OnTextCommitted(this, &SEdNode_GenericGraphNode::OnNameTextCommited)
+									.IsReadOnly(this, &SEdNode_GenericGraphNode::IsNameReadOnly)
+									.IsSelected(this, &SEdNode_GenericGraphNode::IsSelectedExclusively)
+								]
+								+SVerticalBox::Slot()
+								.AutoHeight()
+								[
+									NodeTitle.ToSharedRef()
+								]
 							]
 						]
 					]
@@ -247,37 +218,14 @@ void SEdNode_GenericGraphNode::CreatePinWidgets()
 void SEdNode_GenericGraphNode::AddPin(const TSharedRef<SGraphPin>& PinToAdd)
 {
 	PinToAdd->SetOwner(SharedThis(this));
-
-	const UEdGraphPin* PinObj = PinToAdd->GetPinObj();
-	const bool bAdvancedParameter = PinObj && PinObj->bAdvancedView;
-	if (bAdvancedParameter)
-	{
-		PinToAdd->SetVisibility( TAttribute<EVisibility>(PinToAdd, &SGraphPin::IsPinVisibleAsAdvanced) );
-	}
-
-	if (PinToAdd->GetDirection() == EEdGraphPinDirection::EGPD_Input)
-	{
-		LeftNodeBox->AddSlot()
-			.HAlign(HAlign_Fill)
-			.VAlign(VAlign_Fill)
-			.FillHeight(1.0f)
-			.Padding(20.0f,0.0f)
-			[
-				PinToAdd
-			];
-		InputPins.Add(PinToAdd);
-	}
-	else // Direction == EEdGraphPinDirection::EGPD_Output
-	{
-		OutputPinBox->AddSlot()
-			.HAlign(HAlign_Fill)
-			.VAlign(VAlign_Fill)
-			.FillWidth(1.0f)
-			[
-				PinToAdd
-			];
-		OutputPins.Add(PinToAdd);
-	}
+	RightNodeBox->AddSlot()
+		.HAlign(HAlign_Fill)
+		.VAlign(VAlign_Fill)
+		.FillHeight(1.0f)
+		[
+			PinToAdd
+		];
+	OutputPins.Add(PinToAdd);
 }
 
 bool SEdNode_GenericGraphNode::IsNameReadOnly() const

--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/SEdNode_GenericGraphNode.h
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/SEdNode_GenericGraphNode.h
@@ -28,6 +28,6 @@ public:
 	virtual const FSlateBrush* GetNameIcon() const;
 
 protected:
-	TSharedPtr<SBorder> NodeBody;
-	TSharedPtr<SHorizontalBox> OutputPinBox;
+//	TSharedPtr<SBorder> NodeBody;
+
 };

--- a/Source/GenericGraphEditor/Private/GenericGraphEditor.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphEditor.cpp
@@ -1,50 +1,11 @@
+#include "GenericGraphEditor.h"
+#include "GenericGraphNodeFactory.h"
 #include "AssetTypeActions_GenericGraph.h"
-#include "GenericGraphEditorPCH.h"
-#include "EdGraphUtilities.h"
-#include "GenericGraphAssetEditor/EdNode_GenericGraphNode.h"
-#include "GenericGraphAssetEditor/EdNode_GenericGraphEdge.h"
-#include "GenericGraphAssetEditor/SEdNode_GenericGraphNode.h"
-#include "GenericGraphAssetEditor/SEdNode_GenericGraphEdge.h"
 #include "GenericGraphAssetEditor/GenericGraphEditorStyle.h"
 
 DEFINE_LOG_CATEGORY(GenericGraphEditor)
 
 #define LOCTEXT_NAMESPACE "Editor_GenericGraph"
-
-class FGraphPanelNodeFactory_GenericGraph : public FGraphPanelNodeFactory
-{
-	virtual TSharedPtr<class SGraphNode> CreateNode(UEdGraphNode* Node) const override
-	{
-		if (UEdNode_GenericGraphNode* EdNode_GraphNode = Cast<UEdNode_GenericGraphNode>(Node))
-		{
-			return SNew(SEdNode_GenericGraphNode, EdNode_GraphNode);
-		}
-		else if (UEdNode_GenericGraphEdge* EdNode_Edge = Cast<UEdNode_GenericGraphEdge>(Node))
-		{
-			return SNew(SEdNode_GenericGraphEdge, EdNode_Edge);
-		}
-		return nullptr;
-	}
-};
-
-TSharedPtr<FGraphPanelNodeFactory> GraphPanelNodeFactory_GenericGraph;
-
-class FGenericGraphEditor : public IGenericGraphEditor
-{
-	/** IModuleInterface implementation */
-	virtual void StartupModule() override;
-	virtual void ShutdownModule() override;
-
-private:
-	void RegisterAssetTypeAction(IAssetTools& AssetTools, TSharedRef<IAssetTypeActions> Action);
-
-private:
-	TArray< TSharedPtr<IAssetTypeActions> > CreatedAssetTypeActions;
-
-	EAssetTypeCategories::Type GenericGraphAssetCategoryBit;
-};
-
-IMPLEMENT_MODULE( FGenericGraphEditor, GenericGraphEditor )
 
 void FGenericGraphEditor::StartupModule()
 {

--- a/Source/GenericGraphEditor/Private/GenericGraphEditorPCH.h
+++ b/Source/GenericGraphEditor/Private/GenericGraphEditorPCH.h
@@ -6,7 +6,7 @@
 
 // You should place include statements to your module's private header files here.  You only need to
 // add includes for headers that are used in most of your module's source files though.
-#include "IGenericGraphEditor.h"
+#include "GenericGraphEditor.h"
 
 #define LOG_INFO(FMT, ...) UE_LOG(GenericGraphEditor, Display, (FMT), ##__VA_ARGS__)
 #define LOG_WARNING(FMT, ...) UE_LOG(GenericGraphEditor, Warning, (FMT), ##__VA_ARGS__)

--- a/Source/GenericGraphEditor/Private/GenericGraphFactory.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphFactory.cpp
@@ -1,7 +1,56 @@
 #include "GenericGraphFactory.h"
 #include "GenericGraph.h"
 
+#include "ClassViewerModule.h"
+#include "ClassViewerFilter.h"
+#include "Kismet2/SClassPickerDialog.h"
+
 #define LOCTEXT_NAMESPACE "GenericGraphFactory"
+
+class FAssetClassParentFilter : public IClassViewerFilter
+{
+public:
+	FAssetClassParentFilter()
+		: DisallowedClassFlags(CLASS_None), bDisallowBlueprintBase(false)
+	{}
+
+	/** All children of these classes will be included unless filtered out by another setting. */
+	TSet< const UClass* > AllowedChildrenOfClasses;
+
+	/** Disallowed class flags. */
+	EClassFlags DisallowedClassFlags;
+
+	/** Disallow blueprint base classes. */
+	bool bDisallowBlueprintBase;
+
+	virtual bool IsClassAllowed(const FClassViewerInitializationOptions& InInitOptions, const UClass* InClass, TSharedRef< FClassViewerFilterFuncs > InFilterFuncs) override
+	{
+		bool bAllowed= !InClass->HasAnyClassFlags(DisallowedClassFlags)
+			&& InFilterFuncs->IfInChildOfClassesSet(AllowedChildrenOfClasses, InClass) != EFilterReturn::Failed;
+
+		if (bAllowed && bDisallowBlueprintBase)
+		{
+			if (FKismetEditorUtilities::CanCreateBlueprintOfClass(InClass))
+			{
+				return false;
+			}
+		}
+
+		return bAllowed;
+	}
+
+	virtual bool IsUnloadedClassAllowed(const FClassViewerInitializationOptions& InInitOptions, const TSharedRef< const IUnloadedBlueprintData > InUnloadedClassData, TSharedRef< FClassViewerFilterFuncs > InFilterFuncs) override
+	{
+		if (bDisallowBlueprintBase)
+		{
+			return false;
+		}
+
+		return !InUnloadedClassData->HasAnyClassFlags(DisallowedClassFlags)
+			&& InFilterFuncs->IfInChildOfClassesSet(AllowedChildrenOfClasses, InUnloadedClassData) != EFilterReturn::Failed;
+	}
+};
+
 
 UGenericGraphFactory::UGenericGraphFactory()
 {
@@ -15,9 +64,48 @@ UGenericGraphFactory::~UGenericGraphFactory()
 
 }
 
+bool UGenericGraphFactory::ConfigureProperties()
+{
+	// nullptr the GenericGraphClass so we can check for selection
+	GenericGraphClass = nullptr;
+
+	// Load the classviewer module to display a class picker
+	FClassViewerModule& ClassViewerModule = FModuleManager::LoadModuleChecked<FClassViewerModule>("ClassViewer");
+
+	// Fill in options
+	FClassViewerInitializationOptions Options;
+	Options.Mode = EClassViewerMode::ClassPicker;
+
+	TSharedPtr<FAssetClassParentFilter> Filter = MakeShareable(new FAssetClassParentFilter);
+	Options.ClassFilter = Filter;
+
+	Filter->DisallowedClassFlags = CLASS_Abstract | CLASS_Deprecated | CLASS_NewerVersionExists | CLASS_HideDropDown;
+	Filter->AllowedChildrenOfClasses.Add(UGenericGraph::StaticClass());
+
+	const FText TitleText = LOCTEXT("CreateGenericGraphAssetOptions", "Pick Generic Graph Class");
+	UClass* ChosenClass = nullptr;
+	const bool bPressedOk = SClassPickerDialog::PickClass(TitleText, Options, ChosenClass, UGenericGraph::StaticClass());
+
+	if ( bPressedOk )
+	{
+		GenericGraphClass = ChosenClass;
+	}
+
+	return bPressedOk;
+}
+
 UObject* UGenericGraphFactory::FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn)
 {
-	return NewObject<UObject>(InParent, Class, Name, Flags | RF_Transactional);
+	if (GenericGraphClass != nullptr)
+	{
+		return NewObject<UGenericGraph>(InParent, GenericGraphClass, Name, Flags | RF_Transactional);
+	}
+	else
+	{
+		check(Class->IsChildOf(UGenericGraph::StaticClass()));
+		return NewObject<UObject>(InParent, Class, Name, Flags | RF_Transactional);
+	}
+
 }
 
 #undef LOCTEXT_NAMESPACE

--- a/Source/GenericGraphEditor/Private/GenericGraphFactory.h
+++ b/Source/GenericGraphEditor/Private/GenericGraphFactory.h
@@ -2,6 +2,7 @@
 
 #include "CoreMinimal.h"
 #include "Factories/Factory.h"
+#include "GenericGraph.h"
 #include "GenericGraphFactory.generated.h"
 
 UCLASS()
@@ -13,5 +14,9 @@ public:
 	UGenericGraphFactory();
 	virtual ~UGenericGraphFactory();
 
+	UPROPERTY(EditAnywhere, Category=DataAsset)
+	TSubclassOf<UGenericGraph> GenericGraphClass;
+
+	virtual bool ConfigureProperties() override;
 	virtual UObject* FactoryCreateNew(UClass* Class, UObject* InParent, FName Name, EObjectFlags Flags, UObject* Context, FFeedbackContext* Warn) override;
 };

--- a/Source/GenericGraphEditor/Private/GenericGraphNodeFactory.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphNodeFactory.cpp
@@ -1,0 +1,20 @@
+#include "GenericGraphNodeFactory.h"
+#include <EdGraph/EdGraphNode.h>
+#include "GenericGraphAssetEditor/SEdNode_GenericGraphEdge.h"
+#include "GenericGraphAssetEditor/EdNode_GenericGraphNode.h"
+#include "GenericGraphAssetEditor/SEdNode_GenericGraphNode.h"
+#include "GenericGraphAssetEditor/EdNode_GenericGraphEdge.h"
+
+TSharedPtr<class SGraphNode> FGraphPanelNodeFactory_GenericGraph::CreateNode(UEdGraphNode* Node) const
+{
+	if (UEdNode_GenericGraphNode* EdNode_GraphNode = Cast<UEdNode_GenericGraphNode>(Node))
+	{
+		return SNew(SEdNode_GenericGraphNode, EdNode_GraphNode);
+	}
+	else if (UEdNode_GenericGraphEdge* EdNode_Edge = Cast<UEdNode_GenericGraphEdge>(Node))
+	{
+		return SNew(SEdNode_GenericGraphEdge, EdNode_Edge);
+	}
+	return nullptr;
+}
+

--- a/Source/GenericGraphEditor/Public/GenericGraphEditor.h
+++ b/Source/GenericGraphEditor/Public/GenericGraphEditor.h
@@ -1,0 +1,25 @@
+#pragma once
+#include "Modules/ModuleManager.h"
+#include "GenericGraphEditorModule.h"
+#include <IAssetTools.h>
+#include <EdGraphUtilities.h>
+
+class FGenericGraphEditor : public IGenericGraphEditor
+{
+	/** IModuleInterface implementation */
+	virtual void StartupModule() override;
+	virtual void ShutdownModule() override;
+
+
+private:
+	void RegisterAssetTypeAction(IAssetTools& AssetTools, TSharedRef<IAssetTypeActions> Action);
+
+private:
+	TArray< TSharedPtr<IAssetTypeActions> > CreatedAssetTypeActions;
+
+	EAssetTypeCategories::Type GenericGraphAssetCategoryBit;
+
+	TSharedPtr<FGraphPanelNodeFactory> GraphPanelNodeFactory_GenericGraph;
+};
+
+IMPLEMENT_MODULE(FGenericGraphEditor, GenericGraphEditor)

--- a/Source/GenericGraphEditor/Public/GenericGraphEditorModule.h
+++ b/Source/GenericGraphEditor/Public/GenericGraphEditorModule.h
@@ -1,5 +1,3 @@
-#pragma once
-
 #include"Modules/ModuleManager.h"
 
 DECLARE_LOG_CATEGORY_EXTERN(GenericGraphEditor, Log, All);
@@ -20,7 +18,7 @@ public:
 	 */
 	static IGenericGraphEditor& Get()
 	{
-		return FModuleManager::LoadModuleChecked< IGenericGraphEditor >( "GenericGraphEditor" );
+		return FModuleManager::LoadModuleChecked< IGenericGraphEditor >("GenericGraphEditor");
 	}
 
 	/**
@@ -30,7 +28,7 @@ public:
 	 */
 	static bool IsAvailable()
 	{
-		return FModuleManager::Get().IsModuleLoaded( "GenericGraphEditor" );
+		return FModuleManager::Get().IsModuleLoaded("GenericGraphEditor");
 	}
 };
 

--- a/Source/GenericGraphEditor/Public/GenericGraphNodeFactory.h
+++ b/Source/GenericGraphEditor/Public/GenericGraphNodeFactory.h
@@ -1,0 +1,8 @@
+#pragma once
+#include <EdGraphUtilities.h>
+#include <EdGraph/EdGraphNode.h>
+
+class FGraphPanelNodeFactory_GenericGraph : public FGraphPanelNodeFactory
+{
+	virtual TSharedPtr<class SGraphNode> CreateNode(UEdGraphNode* Node) const override;
+};

--- a/Source/GenericGraphRuntime/Private/GenericGraphNode.cpp
+++ b/Source/GenericGraphRuntime/Private/GenericGraphNode.cpp
@@ -14,7 +14,6 @@ UGenericGraphNode::UGenericGraphNode()
 
 UGenericGraphNode::~UGenericGraphNode()
 {
-
 }
 
 UGenericGraphEdge* UGenericGraphNode::GetEdge(UGenericGraphNode* ChildNode)
@@ -44,8 +43,20 @@ void UGenericGraphNode::SetNodeTitle(const FText& NewTitle)
 	NodeTitle = NewTitle;
 }
 
-bool UGenericGraphNode::CanCreateConnection(UGenericGraphNode* Other, FText& ErrorMessage)
+bool UGenericGraphNode::CanCreateConnection(UGenericGraphNode* Other,int32 OtherNumberOfChildrenNodes, int32 NumberOfParentNodes,FText& ErrorMessage)
 {
+	if (ParentLimitType == ENodeLimit::Limited && NumberOfParentNodes >= ParentLimit)
+	{
+		ErrorMessage = FText::FromString("Parent limit exceeded");
+		return false;
+	}
+	
+	if (Other->ChildrenLimitType == ENodeLimit::Limited && OtherNumberOfChildrenNodes >= Other->ChildrenLimit)
+	{
+		ErrorMessage = FText::FromString("Children limit exceeded");
+		return false;
+	}
+	
 	return true;
 }
 

--- a/Source/GenericGraphRuntime/Private/GenericGraphNode.cpp
+++ b/Source/GenericGraphRuntime/Private/GenericGraphNode.cpp
@@ -43,22 +43,33 @@ void UGenericGraphNode::SetNodeTitle(const FText& NewTitle)
 	NodeTitle = NewTitle;
 }
 
-bool UGenericGraphNode::CanCreateConnection(UGenericGraphNode* Other,int32 OtherNumberOfChildrenNodes, int32 NumberOfParentNodes,FText& ErrorMessage)
+bool UGenericGraphNode::CanCreateConnection(UGenericGraphNode* Other, FText& ErrorMessage)
+{	
+	return true;
+}
+
+bool UGenericGraphNode::CanCreateConnectionTo(UGenericGraphNode* Other, int32 NumberOfChildrenNodes, FText& ErrorMessage)
+{
+	if (ChildrenLimitType == ENodeLimit::Limited && NumberOfChildrenNodes >= ChildrenLimit)
+	{
+		ErrorMessage = FText::FromString("Children limit exceeded");
+		return false;
+	}
+
+	return CanCreateConnection(Other, ErrorMessage);
+}
+
+bool UGenericGraphNode::CanCreateConnectionFrom(UGenericGraphNode* Other, int32 NumberOfParentNodes, FText& ErrorMessage)
 {
 	if (ParentLimitType == ENodeLimit::Limited && NumberOfParentNodes >= ParentLimit)
 	{
 		ErrorMessage = FText::FromString("Parent limit exceeded");
 		return false;
 	}
-	
-	if (Other->ChildrenLimitType == ENodeLimit::Limited && OtherNumberOfChildrenNodes >= Other->ChildrenLimit)
-	{
-		ErrorMessage = FText::FromString("Children limit exceeded");
-		return false;
-	}
-	
+
 	return true;
 }
+
 
 #endif
 

--- a/Source/GenericGraphRuntime/Public/GenericGraph.h
+++ b/Source/GenericGraphRuntime/Public/GenericGraph.h
@@ -53,5 +53,8 @@ public:
 
 	UPROPERTY(EditDefaultsOnly, Category = "GenericGraph_Editor")
 	bool bCanRenameNode;
+
+	UPROPERTY(EditDefaultsOnly, Category = "GenericGraph_Editor")
+	bool bCanBeCyclical;
 #endif
 };

--- a/Source/GenericGraphRuntime/Public/GenericGraphEdge.h
+++ b/Source/GenericGraphRuntime/Public/GenericGraphEdge.h
@@ -24,6 +24,14 @@ public:
 	UPROPERTY(BlueprintReadOnly, Category = "GenericGraphEdge")
 	UGenericGraphNode* EndNode;
 
+	UPROPERTY(EditDefaultsOnly, Category = "GenericGraphEdge")
+	FLinearColor EdgeColour = FLinearColor(0.9f, 0.9f, 0.9f, 1.0f);
+
 	UFUNCTION(BlueprintPure, Category = "GenericGraphEdge")
 	UGenericGraph* GetGraph() const;
+
+	UFUNCTION(BlueprintNativeEvent, Category = "GenericGraphEdge")
+	FLinearColor GetEdgeColour() const;
+	virtual FLinearColor GetEdgeColour_Implementation() const { return EdgeColour; }
+
 };

--- a/Source/GenericGraphRuntime/Public/GenericGraphNode.h
+++ b/Source/GenericGraphRuntime/Public/GenericGraphNode.h
@@ -7,6 +7,14 @@
 class UGenericGraph;
 class UGenericGraphEdge;
 
+UENUM(BlueprintType)
+enum class ENodeLimit : uint8
+{
+	Unlimited,
+    Limited
+};
+
+
 UCLASS(Blueprintable)
 class GENERICGRAPHRUNTIME_API UGenericGraphNode : public UObject
 {
@@ -54,6 +62,19 @@ public:
 
 	UPROPERTY(EditDefaultsOnly, Category = "GenericGraphNode_Editor")
 	FText ContextMenuName;
+
+	UPROPERTY(EditDefaultsOnly, Category = "GenericGraphNode_Editor")
+	ENodeLimit ParentLimitType;
+
+	UPROPERTY(EditDefaultsOnly, Category = "GenericGraphNode_Editor" ,meta = (ClampMin = "0",EditCondition = "ParentLimitType == ENodeLimit::Limited", EditConditionHides))
+	int32 ParentLimit;
+
+	UPROPERTY(EditDefaultsOnly, Category = "GenericGraphNode_Editor")
+	ENodeLimit ChildrenLimitType;
+
+	UPROPERTY(EditDefaultsOnly, Category = "GenericGraphNode_Editor" ,meta = (ClampMin = "0",EditCondition = "ChildrenLimitType == ENodeLimit::Limited", EditConditionHides))
+	int32 ChildrenLimit;
+	
 #endif
 
 #if WITH_EDITOR
@@ -63,6 +84,7 @@ public:
 
 	virtual void SetNodeTitle(const FText& NewTitle);
 
-	virtual bool CanCreateConnection(UGenericGraphNode* Other, FText& ErrorMessage);
+	//virtual bool CanCreateConnection(UGenericGraphNode* Other, FText& ErrorMessage);
+	virtual bool CanCreateConnection(UGenericGraphNode* Other, int32 OtherNumberOfChildrenNodes, int32 NumberOfParentNodes, FText& ErrorMessage);
 #endif
 };

--- a/Source/GenericGraphRuntime/Public/GenericGraphNode.h
+++ b/Source/GenericGraphRuntime/Public/GenericGraphNode.h
@@ -84,7 +84,9 @@ public:
 
 	virtual void SetNodeTitle(const FText& NewTitle);
 
-	//virtual bool CanCreateConnection(UGenericGraphNode* Other, FText& ErrorMessage);
-	virtual bool CanCreateConnection(UGenericGraphNode* Other, int32 OtherNumberOfChildrenNodes, int32 NumberOfParentNodes, FText& ErrorMessage);
+	virtual bool CanCreateConnection(UGenericGraphNode* Other, FText& ErrorMessage);
+
+	virtual bool CanCreateConnectionTo(UGenericGraphNode* Other, int32 NumberOfChildrenNodes, FText& ErrorMessage);
+	virtual bool CanCreateConnectionFrom(UGenericGraphNode* Other, int32 NumberOfParentNodes, FText& ErrorMessage);
 #endif
 };

--- a/Source/GenericGraphRuntime/Public/GenericGraphNode.h
+++ b/Source/GenericGraphRuntime/Public/GenericGraphNode.h
@@ -45,7 +45,7 @@ public:
 	UFUNCTION(BlueprintCallable, Category = "GenericGraphNode")
 	UGenericGraph* GetGraph() const;
 
-	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "MissionNode")
+	UFUNCTION(BlueprintNativeEvent, BlueprintCallable, Category = "GenericGraphNode")
 	FText GetDescription() const;
 	virtual FText GetDescription_Implementation() const;
 


### PR DESCRIPTION
By drawing arrows from input pins to output pins (in reverse), it was possible to create cyclic graphs and to create duplicated edges going in the same direction. This fixes both of these issues by ensuring that the CanCreateConnection logic always runs in the same direction (A -> B), and by adding a sanity check to ensure a edge doesn't already exist connecting the pins.

This also removes the Animation category tag on the Generic Graph asset, so it only shows up in the Generic Graph category.