### PR TITLE
Don't put the GenericGraph asset into the Animation list.

### DIFF
--- a/Source/GenericGraphEditor/Private/AssetTypeActions_GenericGraph.cpp
+++ b/Source/GenericGraphEditor/Private/AssetTypeActions_GenericGraph.cpp
@@ -40,7 +40,7 @@ void FAssetTypeActions_GenericGraph::OpenAssetEditor(const TArray<UObject*>& InO
 
 uint32 FAssetTypeActions_GenericGraph::GetCategories()
 {
-	return EAssetTypeCategories::Animation | MyAssetCategory;
+	return MyAssetCategory;
 }
 
 //////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
Minor fix. Generic Graph asset was showing up in the Animation category of the New Asset list.