### PR TITLE
Fix bad edge connections

### DIFF
--- a/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetGraphSchema_GenericGraph.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphAssetEditor/AssetGraphSchema_GenericGraph.cpp
@@ -340,6 +340,22 @@ const FPinConnectionResponse UAssetGraphSchema_GenericGraph::CanCreateConnection
 		return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, LOCTEXT("PinError", "Not a valid UGenericGraphEdNode"));
 	}
 
+	// Check that this edge doesn't already exist
+	for (UEdGraphPin *TestPin : EdNode_Out->GetOutputPin()->LinkedTo)
+	{
+		UEdGraphNode* ChildNode = TestPin->GetOwningNode();
+		if (UEdNode_GenericGraphEdge* EdNode_Edge = Cast<UEdNode_GenericGraphEdge>(ChildNode))
+		{
+			ChildNode = EdNode_Edge->GetEndNode();
+		}
+
+		if (ChildNode == EdNode_In)
+		{
+			return FPinConnectionResponse(CONNECT_RESPONSE_DISALLOW, LOCTEXT("PinError", "Nodes are already connected"));
+		}
+	}
+
+
 	FText ErrorMessage;
 	if (!EdNode_Out->GenericGraphNode->CanCreateConnection(EdNode_In->GenericGraphNode, ErrorMessage))
 	{


### PR DESCRIPTION
By drawing arrows from input pins to output pins (in reverse), it was possible to create cyclic graphs and to create duplicated edges going in the same direction. This fixes both of these issues by ensuring that the CanCreateConnection logic always runs in the same direction (A -> B), and by adding a sanity check to ensure a edge doesn't already exist connecting the pins.