### PR TITLE
Fix for issues with unity builds.

### DIFF
--- a/Source/GenericGraphEditor/Private/GenericGraphEditor.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphEditor.cpp
@@ -49,5 +49,7 @@ void FGenericGraphEditor::RegisterAssetTypeAction(IAssetTools& AssetTools, TShar
 	CreatedAssetTypeActions.Add(Action);
 }
 
+IMPLEMENT_MODULE(FGenericGraphEditor, GenericGraphEditor)
+
 #undef LOCTEXT_NAMESPACE
 

--- a/Source/GenericGraphEditor/Private/GenericGraphFactory.cpp
+++ b/Source/GenericGraphEditor/Private/GenericGraphFactory.cpp
@@ -3,6 +3,7 @@
 
 #include "ClassViewerModule.h"
 #include "ClassViewerFilter.h"
+#include "Kismet2/KismetEditorUtilities.h"
 #include "Kismet2/SClassPickerDialog.h"
 
 #define LOCTEXT_NAMESPACE "GenericGraphFactory"

--- a/Source/GenericGraphEditor/Public/GenericGraphEditor.h
+++ b/Source/GenericGraphEditor/Public/GenericGraphEditor.h
@@ -21,5 +21,3 @@ private:
 
 	TSharedPtr<FGraphPanelNodeFactory> GraphPanelNodeFactory_GenericGraph;
 };
-
-IMPLEMENT_MODULE(FGenericGraphEditor, GenericGraphEditor)


### PR DESCRIPTION
There was a missing include for "Kismet2/KismetEditorUtilities.h" which exposed an issue with the Generic graph editor module definiton. This resulted in Multiple definitions of the GenericGraphEditor module. Moving the IMPLEMENT_MODULE from the module header to the cpp will fix any resultant errors with including the file. This will solve at least 3 of the currently open issues at main. 